### PR TITLE
Fix: Downgrade to non-babel compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,2 @@
-require('./es6-compat.js');
-
-module.exports = {
-    default: require('./lib/IAMClient.js').default,
-    errorCode: require('./lib/ErrorCodes.js').errorCode,
-};
+module.exports = require('./lib/IAMClient.js');
+module.exports.errorCode = require('./lib/ErrorCodes.js').errorCode;

--- a/lib/ErrorCodes.js
+++ b/lib/ErrorCodes.js
@@ -1,4 +1,6 @@
-export const errorCode = {
+'use strict'; // eslint-disable-line
+
+const errorCode = {
     WrongFormat: {
         code: 401,
         message: "Data entered by the user has a wrong format."
@@ -26,3 +28,5 @@ export const errorCode = {
             "of an unknown error, exception or failure."
     },
 };
+
+module.exports = errorCode;

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -1,4 +1,6 @@
-import http from 'http';
+'use strict'; // eslint-disable-line
+
+const http = require('http');
 
 const ip = '127.0.0.1';
 const port = '8500';
@@ -16,7 +18,7 @@ const pathForRequests = {
     'delete-account': (metadata) => `/account/${metadata.name}`,
 };
 
-export default class IAMClient {
+class IAMClient {
 
     /**
      *  @returns {String} - returns ip string
@@ -150,7 +152,9 @@ export default class IAMClient {
      * @returns{undefined}
      */
     verifySignatureV2(dict, callback) {
-            this.get('authenticate-v2', dict, '', callback);
+        this.get('authenticate-v2', dict, '', callback);
     }
 
 }
+
+module.exports = IAMClient;


### PR DESCRIPTION
Remove non-supported ES6 feature to run the client without Babel transpiling.
