### PR TITLE
FIX: IAMClient.js and shell.js typos

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -9,7 +9,7 @@ const port = '8500';
  * 'create-access-key': (data) => `/accessKey/${data.accountId}`
  */
 const pathForRequests = {
-    'authenticate-v2': () => '/auth/v2/',
+    'authenticate-v2': () => '/auth/v2',
     'create-account': () => '/account',
     'create-user': () => '/user',
     'create-access-key': () => '/accessKey',
@@ -150,7 +150,7 @@ export default class IAMClient {
      * @returns{undefined}
      */
     verifySignatureV2(dict, callback) {
-            this.get('authenticate-v2', dict, '', callback);
+        this.get('authenticate-v2', dict, '', callback);
     }
 
 }

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -349,6 +349,7 @@ function help(nextStep, code) {
  *
  * @param {String[]} tab - The command line containing an error
  * @param {Function} nextStep - Either prompts or exits depending on the mode
+ * @returns {undefined}
  */
 function errorCommand(tab, nextStep) {
     process.stderr.write(`Command not found : ${tab}${eol}`);


### PR DESCRIPTION
 Fix three lint-preventing typos
- IAMClient.js: route url and extra tab fixed
- shell.js: jsdoc warning fixed
