### PR TITLE
 FIX: Return 400 on bad client input

### DIFF
--- a/lib/ErrorCodes.js
+++ b/lib/ErrorCodes.js
@@ -2,7 +2,7 @@
 
 const errorCode = {
     WrongFormat: {
-        code: 401,
+        code: 400,
         message: "Data entered by the user has a wrong format."
     },
 


### PR DESCRIPTION
 Vault.js was returning 401 upon a bad request from the client.
 The proper code is 400.
- ErrorCodes.js: errorCode[WrongFormat].code is now 400

Same as https://github.com/scality/IronMan-Vault/pull/96
(Note that ErrorCodes.js is in vaultclient, hence IronMan-Vault
will  import it as part of the vaultclient dependency)
