### PR TITLE
FT: set server hostname/port in IAMClient.js

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -2,9 +2,6 @@
 
 const http = require('http');
 
-const ip = '127.0.0.1';
-const port = '8500';
-
 /** @constant
  *   @type {Object} - path for every command
  * The path will contain variable content in future routes, ex:
@@ -22,12 +19,27 @@ const pathForRequests = {
 };
 
 class IAMClient {
-
     /**
-     *  @returns {String} - returns ip string
+     * @param{object} server - hostname/port of the Vault server
+     * @param{string} server.host - hostname or ip of the Vault server
+     * @param{string} server.port - port of the Vault server
      */
-    getIp() {
-        return ip;
+    constructor(server) {
+        if (server) {
+            this.serverHost = server.host;
+            this.serverPort = server.port;
+        } else {
+            this.serverHost = 'localhost';
+            this.serverPort = '8500';
+        }
+    }
+
+    getServerHost() {
+        return this.serverHost;
+    }
+
+    getServerPort() {
+        return this.serverPort;
     }
 
     /**
@@ -79,8 +91,8 @@ class IAMClient {
         const options = {
             method,
             path,
-            host: ip,
-            port,
+            host: this.serverHost,
+            port: this.serverPort,
         };
         let ret = '';
         const req = http.request(options);

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -4,7 +4,7 @@ import { EOL as eol } from 'os';
 
 import IAMClient from './IAMClient.js';
 
-const client = new IAMClient();
+const client = new IAMClient({host: 'localhost', port: '8500'});
 let rl;
 
 /** @constant
@@ -526,7 +526,8 @@ function completer(line) {
  *  an interactive shell
  */
 export function interactiveStart() {
-    process.stdout.write(`Connected to : ${client.getIp()}${eol}`);
+    process.stdout.write(`Connected to : ${client.getServerHostname()}` +
+        `:${client.getServerPort()}${eol}`);
     rl = readline.createInterface({input: process.stdin, output: process.stdout,
         completer});
 


### PR DESCRIPTION
 Vault's server hostname/port was hardcoded in
 the client so far. This commit adds a constructor
 to IAMClient.js that accepts a dictionary with
 {hostname,port}. 'hostname' can also be an IP
 if needed.
- IAMClient.js: add the constructor and
  localhost:8500 by default
- shell.js: refactor accordingly
