### PR TITLE
BF  Fix CLI typo in the connected message

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -526,7 +526,7 @@ function completer(line) {
  *  an interactive shell
  */
 export function interactiveStart() {
-    process.stdout.write(`Connected to : ${client.getServerHostname()}` +
+    process.stdout.write(`Connected to : ${client.getServerHost()}` +
         `:${client.getServerPort()}${eol}`);
     rl = readline.createInterface({input: process.stdin, output: process.stdout,
         completer});


### PR DESCRIPTION
 When the CLI it reports a successful connection to the
 vault server with a message like
  Connected to : localhost:8500
 The code generating that message had a small typo where
 getServerHostname was called instead of getServerHost

This fixes issue #15 
