### PR TITLE
Fix verifySignatureV2 parameters structure

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -178,12 +178,10 @@ class IAMClient {
         assert(algo === 'sha1' || algo === 'sha256',
                'options.algo must be sha1 or sha256');
 
-        const data = {
-            stringToSign: string,
-            signatureFromRequest: signature,
-            hashAlgorithm: algo,
-            accessKey,
-        };
+        const data = { additionaldata: { stringToSign: string,
+                                         signatureFromRequest: signature,
+                                         hashAlgorithm: algo,
+                                         accessKey } };
         data[requestUidKey] = options.reqUid;
         this.request('GET', '/auth/v2', callback, data);
     }


### PR DESCRIPTION
The vaultd server expects data to be formatted like:

```
{ additionaldata: { stringToSign: string,
                    signatureFromRequest: signature,
                    hashAlgorithm: algo,
                    accessKey },
  x-scal-request-uids: UUID }
```

not:

```
{ stringToSign: string,
  signatureFromRequest: signature,
  hashAlgorithm: algo,
  accessKey,
  x-scal-request-uids: UUID }
```
