### PR TITLE
FIX: Own repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
-  "repository": "scality/IronMan-VaultClient",
+  "repository": "scality/vaultclient",
   "author": "Scality",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
 Package.json points at scality/IronMan-VaultClient instead of
 scality/vaultclient.

 Fix https://github.com/scality/vaultclient/issues/17
