### PR TITLE
verifySignatureV2: Pass reqUid only when provided

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -182,7 +182,9 @@ class IAMClient {
                                          signatureFromRequest: signature,
                                          hashAlgorithm: algo,
                                          accessKey } };
-        data[requestUidKey] = options.reqUid;
+        if (options.reqUid !== undefined) {
+            data[requestUidKey] = options.reqUid;
+        }
         this.request('GET', '/auth/v2', callback, data);
     }
 


### PR DESCRIPTION
Providing the request UID (associated with the header field
'x-scal-request-uids') should not be mandatory: for instance in
functional or unit tests, it can be omitted. Hence, vaultclient should
not pass it in headers when it's not provided by the caller.
