### PR TITLE
Doc/https and credentials rel1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,37 @@ $ bin/vaultclient create-account --name account0 --email d3v@null \
 
 ```
 
+### Command-line use of Vault administration credentials
+
+Vault requires the use of AWS signature v4 and valid administration credentials
+in its administrative interfaces (that is, create, delete and list
+accounts, users and access keys). In order to make vaultcient use an
+administrative credential (accessKey, secretKey) pair you must first create a
+json file like this:
+
+```
+{
+    "accessKey": "<administrative access key for Vault>",
+    "secretKeyValue": "<administrative secret key for Vault>"
+}
+```
+
+There are three ways of passing the content of the file to vaultclient:
+
+1. Name the file `.vaultclient.conf` and place it in your home folder, that is: `~/.vaultclient.conf`
+
+2. Set environment variable `VAULT_CONFIG` with the path of the file: `export VAULT_CONFIG=<filepath>`
+
+3. Pass the filepath in the command line with option `--config`
+
+An example of the third option is:
+
+```sh
+$ bin/vaultclient create-account --name account0 --email d3v@null \
+                                 --password alpine --host 127.0.0.1 \
+                                 --config <path>
+```
+
 ## Javascript API usage
 
 This is a basic example of how to use the library and the type of objects
@@ -103,6 +134,8 @@ const vaultclient = require('vaultclient');
 
 const client = new vaultclient.Client('auth.mydomain.com');
 
+// the constructor's signature is vaultclient.Client(host, port, useHttps, key,
+// cert, ca, ignoreCa, accessKey, secretKeyValue)
 client.createAccount('account0', { email: 'dev@null', password: 'pass' },
     (err, data) => {
         console.log(data);
@@ -149,7 +182,7 @@ to true.
 const vaultclient = require('vaultclient');
 
 // the constructor's signature is vaultclient.Client(host, port, useHttps, key,
-    cert, ca)
+// cert, ca, ignoreCa, accessKey, secretKeyValue)
 const client = new vaultclient.Client('auth.mydomain.com', 8500, true);
 
 client.createAccount('account0', { email: 'dev@null', password: 'pass' },
@@ -171,6 +204,36 @@ To enable two way https encryption, set the constructor argument 'cert' and
 'key' to the content of the client certificate. To use your own certificate
 authority, set the constructor argument 'ca' to the content of your
 authority certificate.
+
+### Javascript API use of Vault administration credentials
+
+Vault administrative credentials must be passed to the constructor if using
+an administrative route.
+
+```js
+const vaultclient = require('vaultclient');
+
+// the constructor's signature is vaultclient.Client(host, port, useHttps, key,
+// cert, ca, ignoreCa, accessKey, secretKeyValue)
+const client = new vaultclient.Client('auth.mydomain.com', 8500, false,
+                                       undefined, undefined, undefined, true,
+                                       '7C66DCVN609K7ZHDBVZ0',
+                                       'JXxTT04NxiWb6NcES+rpkHnkXszDq3KxexocJIJ9');
+
+client.createAccount('account0', { email: 'dev@null', password: 'pass' },
+    (err, data) => {
+        console.log(data);
+});
+
+// { message:
+//    { code: 201,
+//      message: 'Created',
+//      body:
+//       { arn: 'arn:aws:iam::040564259525:/account0/',
+//         id: '040564259525',
+//         canonicalId: 'A6QOM41TPP9P7KQ37M0I5DN8DQ88LJ6KCL9C8E...EZMFGBD' } } }
+
+```
 
 [badgepub]: https://circleci.com/gh/scality/vaultclient.svg?style=svg
 [badgepriv]: http://ci.ironmann.io/gh/scality/vaultclient.svg?style=svg&circle-token=40f1e9fe0ad184248c37cbf3d89b164c35fd1667

--- a/README.md
+++ b/README.md
@@ -93,30 +93,6 @@ $ bin/vaultclient create-account --name account0 --email d3v@null \
 
 ```
 
-### Command-line HTTPS support
-
-The command-line tool uses the HTTP protocol by default. To force the use of
-HTTPS, include the option '--https' in every command. You can also specify your
-own certificate authority by including the option '--cafile'. Example:
-
-```sh
-$ bin/vaultclient create-account --name account0 --email d3v@null \
-                                 --password alpine --host 127.0.0.1 --https \
-                                 --cafile <path>
-{
-    "message": {
-        "code": 201,
-        "message": "Created",
-        "body": {
-            "arn": "arn:aws:iam::456854744086:/account0/",
-            "id": "456854744086",
-            "canonicalId": "7E27S2BXH4JC3Y2CMUOEMO4UJ0I2D5TP4Q...VD7J6SCV7FEM8T"
-        }
-    }
-}
-
-```
-
 ## Javascript API usage
 
 This is a basic example of how to use the library and the type of objects


### PR DESCRIPTION
PR https://github.com/scality/vaultclient/pull/79 was open against master by mistake, reopening against rel/1.1.

This PR adds much needed documentation about the configuration of admin credentials (HTTPS was already there).