### PR TITLE
[Api](ft): Make s3 routes real GET requests

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -5,7 +5,6 @@ const auth = require('arsenal').auth;
 const assert = require('assert');
 const http = require('http');
 const https = require('https');
-const requestUidKey = 'x-scal-request-uids';
 const parseString = require('xml2js').parseString;
 const queryString = require('querystring');
 
@@ -202,14 +201,25 @@ class IAMClient {
         assert(algo === 'sha1' || algo === 'sha256',
                'options.algo must be sha1 or sha256');
 
-        const data = { additionaldata: { stringToSign: string,
-                                         signatureFromRequest: signature,
-                                         hashAlgorithm: algo,
-                                         accessKey } };
-        if (options.reqUid !== undefined) {
-            data[requestUidKey] = options.reqUid;
-        }
-        this.request('GET', '/auth/v2', callback, data);
+        const data = {
+            Action: 'AuthV2',
+            stringToSign: string,
+            signatureFromRequest: signature,
+            hashAlgorithm: algo,
+            accessKey,
+        };
+        this.request('GET', '/', (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    message: 'Authentication successful',
+                    body: data,
+                    code,
+                },
+            });
+        }, data, options.reqUid);
     }
 
     /**
@@ -239,15 +249,26 @@ class IAMClient {
                'region is required');
         assert(typeof scopeDate === 'string' && scopeDate !== '',
                'scopeDate is required');
-        const data = { additionaldata: { stringToSign,
-                                         signatureFromRequest: signature,
-                                         accessKey,
-                                         region,
-                                         scopeDate } };
-        if (options.reqUid !== undefined) {
-            data[requestUidKey] = options.reqUid;
-        }
-        this.request('GET', '/auth/v4', callback, data);
+        const data = {
+            Action: 'AuthV4',
+            stringToSign,
+            signatureFromRequest: signature,
+            accessKey,
+            region,
+            scopeDate,
+        };
+        this.request('GET', '/', (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    message: 'Authentication successful',
+                    body: data,
+                    code,
+                },
+            });
+        }, data, options.reqUid);
     }
 
     /**
@@ -263,11 +284,22 @@ class IAMClient {
      */
     getEmailAddresses(canonicalIds, options, callback) {
         assert(Array.isArray(canonicalIds), 'canonicalIds are required');
-        const data = { additionaldata: { canonicalIds } };
-        if (options.reqUid !== undefined) {
-            data[requestUidKey] = options.reqUid;
-        }
-        this.request('GET', '/acl/emailAddresses', callback, data);
+        const data = {
+            Action: 'AclEmailAddresses',
+            canonicalIds,
+        };
+        this.request('GET', '/', (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    body: data,
+                    code,
+                    message: 'Attributes retrieved',
+                },
+            });
+        }, data, options.reqUid);
     }
 
     /**
@@ -283,11 +315,22 @@ class IAMClient {
      */
     getCanonicalIds(emailAddresses, options, callback) {
         assert(Array.isArray(emailAddresses), 'emailAddresses are required');
-        const data = { additionaldata: { emailAddresses } };
-        if (options.reqUid !== undefined) {
-            data[requestUidKey] = options.reqUid;
-        }
-        this.request('GET', '/acl/canonicalIds', callback, data);
+        const data = {
+            Action: 'AclCanonicalIds',
+            emailAddresses,
+        };
+        this.request('GET', '/', (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    body: data,
+                    code,
+                    message: 'Attributes retrieved',
+                },
+            });
+        }, data, options.reqUid);
     }
 
     /**
@@ -298,9 +341,10 @@ class IAMClient {
      *                        (while metadata is sent in the URL); data may or
      *                        may not be present depending on the type of
      *                        request
+     * @param {string} reqUid - Request logger uid, to trace request
      * @returns {undefined}
      */
-    request(method, path, callback, data) {
+    request(method, path, callback, data, reqUid) {
         const options = {
             method,
             path,
@@ -316,23 +360,20 @@ class IAMClient {
         }
 
         let ret = '';
+        if (method === 'GET') {
+            if (reqUid) {
+                options.headers = {
+                    'x-scal-request-uids': reqUid,
+                };
+            }
+            options.path += `?${queryString.stringify(data)}`;
+        }
         const req = this.useHttps ?
             https.request(options) : http.request(options);
-
-        if (method === 'POST' && typeof data === 'object') {
+        if (method === 'POST') {
             auth.generateV4Headers(req, data,
                     this.accessKey, this.secretKeyValue, 'iam');
-            req.write(queryString.stringify(data, null, null, {
-                encodeURIComponent,
-            }));
-        } else if (method === 'GET' && typeof data === 'object') {
-            Object.keys(data).forEach(key => {
-                let value = data[key];
-                if (typeof value === 'object') {
-                    value = JSON.stringify(value);
-                }
-                req.setHeader(key, value);
-            });
+            req.write(queryString.stringify(data));
         }
 
 


### PR DESCRIPTION
- Use querystring to send params for s3 get requests
- Send as the same way as IAM request (Action parameter)

To be merge with https://github.com/scality/Vault/pull/398