### PR TITLE
Add requestContext to data sent to vault on auth

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -245,8 +245,11 @@ client.verifySignatureV2(
     'signature',
     'accessKey',
     {
-        algo: 'sha256', // sha1 or sha256 (optionnal)
-        reqUid: 'some-request-id', // Request id to trace request (optionnal)
+        algo: 'sha256', // sha1 or sha256 (optional)
+        reqUid: 'some-request-id', // Request id to trace request (optional)
+        requestContext: '{}', // Request context to perform authorization
+        // against IAM policies. This is a stringified version of a
+        // RequestContext class.  See Arsenal for class details.
     },
     (err, result) => {
         result.message.code; // http result code
@@ -273,7 +276,10 @@ client.verifySignatureV4(
     'us-east-1', // Region
     scopeDate, // Date in ISO 8601 format, YYYYMMDDTHHMMSSZ
     {
-        reqUid: 'some-request-id', // Request id to trace request (optionnal)
+        reqUid: 'some-request-id', // Request id to trace request (optional)
+        requestContext: '{}', // Request context to perform authorization
+        // against IAM policies. This is a stringified version of a
+        // RequestContext class.  See Arsenal for class details.
     },
     (err, result) => {
         result.message.code; // http result code

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -186,6 +186,9 @@ class IAMClient {
      * @param {object} options - additional verification params
      * @param {string} [options.algo] - either 'sha1' 'sha256'
      * @param {string} [options.reqUid] - the request UID
+     * @param {string} [options.requestContext] - the requestContext to perform
+     * authorization against IAM policies. This is a stringified version of a
+     * RequestContext class.  See Arsenal for class details.
      * @param {IAMClient~requestCallback} callback - callback
      * @returns {undefined}
      */
@@ -206,6 +209,7 @@ class IAMClient {
             signatureFromRequest: signature,
             hashAlgorithm: algo,
             accessKey,
+            requestContext: options.requestContext,
         };
         this.request('GET', '/', (err, data, code) => {
             if (err) {
@@ -233,6 +237,9 @@ class IAMClient {
      * @param {string} scopeDate - the date from which the signature is valid
      * @param {object} options - additional verification params
      * @param {string} [options.reqUid] - the request UID
+     * @param {string} [options.requestContext] - the requestContext to perform
+     * authorization against IAM policies. This is a stringified version of a
+     * RequestContext class.  See Arsenal for class details.
      * @param {IAMClient~requestCallback} callback - callback
      * @returns {undefined}
      */
@@ -255,6 +262,7 @@ class IAMClient {
             accessKey,
             region,
             scopeDate,
+            requestContext: options.requestContext,
         };
         this.request('GET', '/', (err, data, code) => {
             if (err) {


### PR DESCRIPTION
This is necessary so that vault has the requestContext for evaluating IAM policies.