### PR TITLE
PERF: improvment

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -449,10 +449,10 @@ class IAMClient {
         const req = this.useHttps ?
             https.request(options) : http.request(options);
 
-        auth.generateV4Headers(req, JSON.stringify(data),
-                               this.accessKey, this.secretKeyValue);
 
         if (method === 'POST' && typeof data === 'object') {
+            auth.generateV4Headers(req, JSON.stringify(data),
+                this.accessKey, this.secretKeyValue);
             req.write(JSON.stringify(data));
         } else if (method === 'GET' && typeof data === 'object') {
             Object.keys(data).forEach(key => {


### PR DESCRIPTION
- Don't compute v4 authentification headers for
  s3 routes (they are unused)

This PR save a lot of cpu usage for s3