### PR TITLE
PERF: improvment

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -449,8 +449,10 @@ class IAMClient {
         const req = this.useHttps ?
             https.request(options) : http.request(options);
 
-        auth.generateV4Headers(req, JSON.stringify(data),
-                               this.accessKey, this.secretKeyValue);
+        if (!path.startsWith('/acl/') && !path.startsWith('/auth/')) {
+            auth.generateV4Headers(req, JSON.stringify(data),
+                                   this.accessKey, this.secretKeyValue);
+        }
 
         if (method === 'POST' && typeof data === 'object') {
             req.write(JSON.stringify(data));


### PR DESCRIPTION
- Don't compute v4 authentification headers for
  s3 routes (they are unused)

This PR save a lot of cpu usage for s3

The previous revert PR does not took in account that rel/1.1 still have GET routes to vault