### PR TITLE
FIX: Add cli option to check vaultclient version

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -10,7 +10,10 @@ const program = require('commander');
 
 const vaultclient = require('../index');
 
-program.option('--host [HOST]', 'host where Vault is running (default to ' +
+const version = require('../package.json').version;
+
+program.version(version)
+        .option('--host [HOST]', 'host where Vault is running (default to ' +
                'VAULT_HOST environment variable)')
        .option('--port [PORT]', 'port where Vault is running (default to ' +
                'VAULT_PORT environment variable)')


### PR DESCRIPTION
Actually, we don't have simple way to check the
vaultclient version, this PR fix that

- Add .version() to commander, so --version will now
  return vaultclient version

Fixes https://github.com/scality/vaultclient/issues/99