### PR TITLE
FT: Fix crypto encoding

### DIFF
--- a/tools/blaster.js
+++ b/tools/blaster.js
@@ -55,7 +55,7 @@ function generateString(size) {
 }
 
 function hmac(stringToSign, key) {
-    return createHmac('sha256', key).update(stringToSign).digest();
+    return createHmac('sha256', key).update(stringToSign, 'binary').digest();
 }
 
 function calculateSigningKeyV4(secretKey) {


### PR DESCRIPTION
in Node v4, default crypto encoding is binary, this
PR specify this encoding to avoid any change in the future
(node v6 in mind)