### PR TITLE
Add checkPolicies method

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -87,7 +87,7 @@ class IAMClient {
         assert(typeof options.email === 'string' && options.email !== '',
                'options.email is required');
 
-        this.request('POST', '/', (err, result) => {
+        this.request('POST', '/', true, (err, result) => {
             if (err) {
                 return callback(err);
             }
@@ -113,7 +113,7 @@ class IAMClient {
         assert(typeof accountName === 'string' && accountName !== '',
                'accountName is required');
 
-        this.request('POST', '/', (err, result) => {
+        this.request('POST', '/', true, (err, result) => {
             if (err) {
                 return callback(err);
             }
@@ -136,7 +136,7 @@ class IAMClient {
         assert(typeof accountName === 'string' && accountName !== '',
                'accountName is required');
 
-        this.request('POST', '/', callback, {
+        this.request('POST', '/', true, callback, {
             Action: 'DeleteAccount',
             Version: '2010-05-08',
             AccountName: accountName,
@@ -173,7 +173,7 @@ class IAMClient {
                 'maxItems need to be a value between 1 and 1000 included');
             data.MaxItems = options.maxItems;
         }
-        this.request('POST', '/', callback, data);
+        this.request('POST', '/', true, callback, data);
     }
 
     /**
@@ -213,7 +213,7 @@ class IAMClient {
         if (options.requestContext) {
             data.requestContext = options.requestContext;
         }
-        this.request('GET', '/', (err, data, code) => {
+        this.request('GET', '/', false, (err, data, code) => {
             if (err) {
                 return callback(err);
             }
@@ -268,7 +268,7 @@ class IAMClient {
         if (options.requestContext) {
             data.requestContext = options.requestContext;
         }
-        this.request('GET', '/', (err, data, code) => {
+        this.request('GET', '/', false, (err, data, code) => {
             if (err) {
                 return callback(err);
             }
@@ -299,7 +299,7 @@ class IAMClient {
             Action: 'AclEmailAddresses',
             canonicalIds,
         };
-        this.request('GET', '/', (err, data, code) => {
+        this.request('GET', '/', false, (err, data, code) => {
             if (err) {
                 return callback(err);
             }
@@ -330,7 +330,7 @@ class IAMClient {
             Action: 'AclCanonicalIds',
             emailAddresses,
         };
-        this.request('GET', '/', (err, data, code) => {
+        this.request('GET', '/', false, (err, data, code) => {
             if (err) {
                 return callback(err);
             }
@@ -345,17 +345,63 @@ class IAMClient {
     }
 
     /**
+     * Get policy evaluation (without authentication first)
+     * @param {Object} requestContextParams - parameters needed to construct
+     * requestContext in Vault
+     * @param {Object} requestContextParams.constantParams -
+     * params that have the
+     * same value for each requestContext to be constructed in Vault
+     * @param {Object} [requestContextParams.paramaterize] - params that have
+     * arrays as values since a requestContext needs to be constructed with
+     * each option in Vault
+     * @param {string} userArn - arn of requesting user
+     * @param {Object} options - additional arguments
+     * @param{String} options.reqUid - the request UID
+     * @param{Function} callback - callback with either error or an array
+     * of authorization results
+     * @returns{undefined}
+     */
+    checkPolicies(requestContextParams, userArn, options, callback) {
+        assert(typeof requestContextParams === 'object',
+            'need requestContextParams');
+        assert(typeof requestContextParams.constantParams === 'object',
+            'need constantParams');
+        assert(typeof userArn === 'string', 'need user arn');
+        const data = {
+            Action: 'CheckPolicies',
+            requestContextParams,
+            userArn,
+        };
+        this.request('POST', '/', false, (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    body: data,
+                    code,
+                    message: 'Policies checked',
+                },
+            });
+        }, data, options.reqUid, 'application/json');
+    }
+
+    /**
      * @param {string} method - CRUD method chosen for the request
      * @param {string} path - RESTful URL for the request
+     * @param {boolean} iamAuthenticate - whether to add iam authentication
+     * headers to request
      * @param {IAMClient~requestCallback} callback - callback
      * @param {object} data - object containing data to be sent through the req
      *                        (while metadata is sent in the URL); data may or
      *                        may not be present depending on the type of
      *                        request
-     * @param {string} reqUid - Request logger uid, to trace request
+     * @param {string} [reqUid] - Request logger uid, to trace request
+     * @param {string} [contentType] - content type of body
      * @returns {undefined}
      */
-    request(method, path, callback, data, reqUid) {
+    request(method, path, iamAuthenticate, callback, data, reqUid,
+        contentType) {
         const options = {
             method,
             path,
@@ -369,24 +415,29 @@ class IAMClient {
             options.key = this._key;
             options.cert = this._cert;
         }
-
+        if (reqUid) {
+            options.headers = {
+                'x-scal-request-uids': reqUid,
+            };
+        }
         let ret = '';
         if (method === 'GET') {
-            if (reqUid) {
-                options.headers = {
-                    'x-scal-request-uids': reqUid,
-                };
-            }
             options.path += `?${queryString.stringify(data)}`;
         }
         const req = this.useHttps ?
             https.request(options) : http.request(options);
-        if (method === 'POST') {
+        if (iamAuthenticate) {
             auth.client.generateV4Headers(req, data,
                     this.accessKey, this.secretKeyValue, 'iam');
-            req.write(queryString.stringify(data));
         }
-
+        if (method === 'POST') {
+            if (contentType === 'application/json') {
+                req.setHeader('Content-Type', contentType);
+                req.write(JSON.stringify(data));
+            } else {
+                req.write(queryString.stringify(data));
+            }
+        }
 
         // request events
         req.on('response', res => {
@@ -433,7 +484,7 @@ class IAMClient {
         if (ret.length === 0) {
             return cb(null, {});
         }
-        if (ret[0] !== '{') {
+        if (ret[0] !== '{' && ret[0] !== '[') {
             return parseString(ret, {
                 explicitArray: false,
             }, (err, result) => {

--- a/tests/unit/checkPoliciesTest.js
+++ b/tests/unit/checkPoliciesTest.js
@@ -1,0 +1,54 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const http = require('http');
+const IAMClient = require('../../lib/IAMClient.js');
+
+const output = [{isAllowed: true, arn: 'arn:aws:s3:::policybucket/obj'}];
+const requestContextParams = {
+    constantParams: {
+        headers: '',
+        query: '',
+        generalResource: 'policybucket',
+        specificResource: 'obj',
+        requesterIp: '',
+        sslEnabled: '',
+        apiMethod: 'objectDelete',
+        awsService: 's3',
+        locationConstraint: null,
+        requesterInfo: '',
+        signatureVersion: '',
+        authType: '',
+        signatureAge: '',
+    },
+};
+const userArn = 'arn:aws:iam::153456779012:user/Claude';
+
+
+function handler(req, res) {
+    res.writeHead(200);
+    return res.end(JSON.stringify(output));
+}
+
+describe('checkPolicies Test', () => {
+    let server;
+    let client;
+
+    beforeEach('start server', done => {
+        server = http.createServer(handler).listen(8500, () => {
+            client = new IAMClient('127.0.0.1', 8500);
+            done();
+        }).on('error', done);
+    });
+
+    afterEach('stop server', () => { server.close(); });
+
+    it('should retrieve checkPolicies response', done => {
+        client.checkPolicies(requestContextParams, userArn,
+            { reqUid: '123' },
+            (err, response) => {
+                assert.deepStrictEqual(response.message.body, output);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
This is needed to do a large batch policy evaluation for multi-object delete (if request is from a user).  This allows us to do an authorization check without an authentication check since for multi-object delete the authentication check is done on its own first.
