### PR TITLE
fix: parse JSON errors

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -545,8 +545,9 @@ class IAMClient {
                 return callback(null, obj, res.statusCode, res.statusMessage);
             }
             // Load the error from errors(arsenal)
-            return callback(
-                errors[obj.ErrorResponse.Error.Code], null, res.statusCode);
+            const retErr = obj.ErrorResponse
+                ? obj.ErrorResponse.Error.Code : obj;
+            return callback(errors[retErr], null, res.statusCode);
         });
     }
 }


### PR DESCRIPTION
This change makes sure healtcheck error responses which are usually
stringfied Arsenal errors are parsed correctly.

Fixes #115