### PR TITLE
ft: add method to retrieve canonical IDs by account IDs

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -349,6 +349,38 @@ class IAMClient {
     }
 
     /**
+     * A getter for account canonical IDs given a list of account IDs
+     * @param{String[]} accountIds - list of account IDs
+     * @param {Object} options - additional arguments
+     * @param {string} options.reqUid - the request UID
+     * @param {werelogs.Logger} [options.logger] - Logger instance
+     * @param{Function} callback - the callback handling the array of objects
+     * and the error, if there is one
+     * @returns{undefined}
+     */
+    getCanonicalIdsByAccountIds(accountIds, options, callback) {
+        assert(Array.isArray(accountIds), 'accountIds must be an array');
+        accountIds.every(item => assert(typeof item === 'string'),
+            'each entry in accountIds must be a string');
+        const data = {
+            Action: 'AccountsCanonicalIds',
+            accountIds,
+        };
+        this.request('GET', '/', false, (err, data, code) => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                message: {
+                    body: data,
+                    code,
+                    message: 'Attributes retrieved',
+                },
+            });
+        }, data, options.reqUid, null, options.logger);
+    }
+
+    /**
      * Get policy evaluation (without authentication first)
      * @param {Object} requestContextParams - parameters needed to construct
      * requestContext in Vault

--- a/tests/unit/getCanonicalIdsByAccountIds.js
+++ b/tests/unit/getCanonicalIdsByAccountIds.js
@@ -1,0 +1,79 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const errors = require('arsenal').errors;
+const http = require('http');
+const IAMClient = require('../../lib/IAMClient.js');
+const querystring = require('querystring');
+
+const canId1 =
+    '0123456789012345678901234567890123456789012345678901234567890123';
+const canId2 =
+    '1234567890123456789012345678901234567890123456789012345678901230';
+const canId3 =
+    '2345678901234567890123456789012345678901234567890123456789012301';
+
+const accountId1 = 'accountId1';
+const accountId2 = 'accountId2';
+const accountId3 = 'accountId3';
+const accountBadId = 'accountBadId';
+
+const serverDB = {};
+serverDB[accountId1] = canId1;
+serverDB[accountId2] = canId2;
+serverDB[accountId3] = canId3;
+
+function handler(req, res) {
+    const index = req.url.indexOf('?');
+    const data = querystring.parse(req.url.substring(index + 1));
+    const inputArray = data.accountIds;
+    if (!Array.isArray(inputArray)) {
+        inputArray = [inputArray];
+    }
+    if (inputArray.indexOf(accountBadId) !== -1) {
+        res.writeHead(errors.InvalidParameterValue.code);
+        return res.end(JSON.stringify(errors.InvalidParameterValue));
+    }
+    const output = [];
+    inputArray.forEach(id => output.push({ accountId: id,
+        canonicalId: serverDB[id] }));
+    res.writeHead(200);
+    return res.end(JSON.stringify(output), null, 4);
+}
+
+describe('getCanonicalIdsByAccountIds with mockup server', () => {
+    let server;
+    let client;
+
+    beforeEach('start server', done => {
+        server = http.createServer(handler).listen(8500);
+        client = new IAMClient('127.0.0.1', 8500);
+        done();
+    });
+
+    afterEach('stop server', () => { server.close(); });
+
+    it('should correctly retrieve canonical Ids', done => {
+        const accountIds = [accountId1, accountId2, accountId3];
+        const expectedRes = [
+            { accountId: accountId1, canonicalId: canId1 },
+            { accountId: accountId2, canonicalId: canId2 },
+            { accountId: accountId3, canonicalId: canId3 },
+        ];
+        client.getCanonicalIdsByAccountIds(accountIds, {}, (err, res) => {
+            if (err) {
+                return done(err);
+            }
+            assert.deepStrictEqual(res.message.body, expectedRes);
+            return done();
+        });
+    });
+
+    it('should return error when server returns an error', done => {
+        const accountIds = [accountId1, accountId2, accountId3, accountBadId];
+        client.getCanonicalIdsByAccountIds(accountIds, {}, err => {
+            assert(err);
+            return done();
+        });
+    });
+});


### PR DESCRIPTION
This method is used by Utapi to retrieve a list of canonical Ids given a list
of accountIds.