### PR TITLE
FIX: Update valid marker checking

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -118,7 +118,7 @@ program
 
 program
     .command('list-accounts')
-    .option('--marker [MARKER]', 'Marker for pagination', parseInt)
+    .option('--marker [MARKER]', 'Marker for pagination')
     .option('--maxItems [MAXITEMS]', 'Max items for pagination', parseInt)
     .action(action.bind(null, 'list-accounts', (client, args) => {
         client.listAccounts({

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -158,10 +158,10 @@ class IAMClient {
             Version: '2010-05-08',
         };
         if (typeof options.marker !== 'undefined') {
-            const marker = parseInt(options.marker, 10);
-            assert.notStrictEqual(isNaN(marker), true,
+            const marker = options.marker;
+            assert.notStrictEqual(isNaN(marker) || marker === '', true,
                 'Marker must be a number');
-            assert(marker >= 0, 'Marker must be >= 0');
+            assert(Number(marker) >= 0, 'Marker must be >= 0');
             data.Marker = marker;
         }
         if (typeof options.maxItems !== 'undefined') {


### PR DESCRIPTION
Depends on scality/Vault#729.

With changes introduced by scality/Vault#729, we need to preserve leading zeros in any marker value. `parseInt` method removes them, so we need to check for a marker's validity as a Number without using it.