### PR TITLE
ft: add path prefix support

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -23,9 +23,10 @@ class VaultClient {
      * @param {string} [secretKeyValue] - secretKeyValue for v4 signature
      * @param {Werelogs.API} [logApi] - object providing a constructor function
      *                                  for the Logger object
+     * @param {string} [path] - prefix requests with this path
      */
     constructor(host, port, useHttps, key, cert, ca, ignoreCa,
-                accessKey, secretKeyValue, logApi) {
+                accessKey, secretKeyValue, logApi, path) {
         assert(typeof host === 'string' && host !== '', 'host is required');
         assert(port === undefined || typeof port === 'number',
                'port must be a number');
@@ -35,6 +36,9 @@ class VaultClient {
                 'cert must be a string');
         assert(ca === undefined || typeof ca === 'string',
                 'ca must be a string');
+        assert(path === undefined ||
+            (typeof path === 'string' && path.startsWith('/')),
+            'path must be a string and start with a "/"');
         this.serverHost = host;
         this.serverPort = port || 8600;
         this._key = key;
@@ -57,6 +61,7 @@ class VaultClient {
         this.secretKeyValue = secretKeyValue;
         this.logApi = logApi || werelogs;
         this.log = new this.logApi.Logger('VaultClient');
+        this._path = path;
     }
 
    /**
@@ -483,7 +488,7 @@ class VaultClient {
             this.log.newRequestLogger();
         const options = {
             method,
-            path,
+            path: this._path || path,
             host: this.serverHost,
             hostname: this.serverHost,
             port: this.serverPort,

--- a/tests/unit/pathPrefix.js
+++ b/tests/unit/pathPrefix.js
@@ -1,0 +1,41 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const http = require('http');
+const IAMClient = require('../../lib/IAMClient.js');
+const path = '/_/test';
+const roleArn = 'arn:aws:iam::123456789:role/test';
+const roleSessionName = 'foo';
+
+function handler(req, res) {
+    if (req.url === path) {
+        res.writeHead(200);
+        return res.end();
+    }
+    res.writeHead(400);
+    return res.end();
+}
+
+describe('path prefix test with path parameter set', () => {
+    let server;
+    let client;
+
+    beforeEach('start server', done => {
+        server = http.createServer(handler).listen(8500, () => {
+            client = new IAMClient('127.0.0.1', 8500, undefined, undefined,
+                undefined, undefined, undefined, undefined, undefined,
+                undefined, path);
+            done();
+        }).on('error', done);
+    });
+
+    afterEach('stop server', () => { server.close(); });
+
+    it('should send a request with the set path', done => {
+        client.assumeRoleBackbeat(roleArn, roleSessionName, { reqUid: '1'},
+            err => {
+                assert.strictEqual(err, null);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
This commit adds an optional path param to the constuctor which can be
used to send requests using url prefixed with that path to the server.
This feature can be leveraged to proxy requests to a frontend.