### PR TITLE
ft: use proxy for authenticated routes

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -512,7 +512,7 @@ class VaultClient {
             https.request(options) : http.request(options);
         if (iamAuthenticate) {
             auth.client.generateV4Headers(req, data,
-                    this.accessKey, this.secretKeyValue, 'iam');
+                    this.accessKey, this.secretKeyValue, 'iam', path);
         }
         if (method === 'POST') {
             if (contentType === 'application/json') {


### PR DESCRIPTION
When using a proxy path, for example `/_/backbeat`, we cannot use methods that need authentication. For example, using `createAccount` method would cause `SignatureDoesNotMatch` error as the request path is used in signature calculation. This commit patches the path before signature calculation to match the string to sign at Vault.