### PR TITLE
ft: S3C-1561 - add, update and delete account quotas

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -13,16 +13,16 @@ const vaultclient = require('../index');
 const version = require('../package.json').version;
 
 program.version(version)
-        .option('--host [HOST]', 'host where Vault is running (default to ' +
-               'VAULT_HOST environment variable)')
-       .option('--port [PORT]', 'port where Vault is running (default to ' +
-               'VAULT_PORT environment variable)')
-       .option('--https', 'use HTTPs instead of the default HTTP')
-       .option('--cafile [FILE]', 'Authority certificate to use')
-       .option('--noCaVerification', 'Allow untrusted certificate authority')
-       .option('--config [PATH]', 'path where the configuration for ' +
-                'vaultclient is (defaults to VAULT_CONFIG environment ' +
-                'variable and ~/.vaultclient.conf in that order)');
+    .option('--host [HOST]', 'host where Vault is running (default to ' +
+        'VAULT_HOST environment variable)')
+    .option('--port [PORT]', 'port where Vault is running (default to ' +
+        'VAULT_PORT environment variable)')
+    .option('--https', 'use HTTPs instead of the default HTTP')
+    .option('--cafile [FILE]', 'Authority certificate to use')
+    .option('--noCaVerification', 'Allow untrusted certificate authority')
+    .option('--config [PATH]', 'path where the configuration for ' +
+        'vaultclient is (defaults to VAULT_CONFIG environment ' +
+        'variable and ~/.vaultclient.conf in that order)');
 
 function checkConfig(configObject) {
     if (!configObject) {
@@ -40,7 +40,7 @@ function readConfigFile(configFilePath) {
     let actualPath = path.join(homedir(), '.vaultclient.conf');
     if (configFilePath) {
         actualPath = configFilePath;
-    } else if(process.env.VAULT_CONFIG) {
+    } else if (process.env.VAULT_CONFIG) {
         actualPath = process.env.VAULT_CONFIG;
     }
     try {
@@ -103,9 +103,13 @@ program
     .command('create-account')
     .option('--name <NAME>')
     .option('--email <EMAIL>')
+    .option('--quota <Quota>', 'Maximum quota for the account', parseInt)
     .action(action.bind(null, 'create-account', (client, args) => {
         client.createAccount(
-            args.name, { email: args.email },
+            args.name, {
+                email: args.email,
+                quota: args.quota || null
+            },
             handleVaultResponse);
     }));
 
@@ -125,6 +129,22 @@ program
             marker: args.marker,
             maxItems: args.maxItems,
         }, handleVaultResponse);
+    }));
+
+program
+    .command('update-account-quota')
+    .option('--account-name <NAME>', 'Name of the account')
+    .option('--quota <QUOTA>', 'Maximum quota for the account', parseInt)
+    .action(action.bind(null, 'update-account-quota', (client, args) => {
+        client.updateAccountQuota(args.accountName, args.quota,
+            handleVaultResponse);
+    }));
+
+program
+    .command('delete-account-quota')
+    .option('--account-name <NAME>', 'Name of the account')
+    .action(action.bind(null, 'delete-account-quota', (client, args) => {
+        client.deleteAccountQuota(args.accountName, handleVaultResponse);
     }));
 
 program

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -64,11 +64,11 @@ class VaultClient {
         this._path = path;
     }
 
-   /**
-    * Set the configuration for the werelogs logger
-    * @param {object} config - A configuration object for werelogs
-    * @returns {undefined}
-    */
+    /**
+     * Set the configuration for the werelogs logger
+     * @param {object} config - A configuration object for werelogs
+     * @returns {undefined}
+     */
     setLoggerConfig(config) {
         this.logApi.configure(config);
     }
@@ -96,7 +96,7 @@ class VaultClient {
      * @param {string} accountName - account name
      * @param {object} options - additional creation params
      * @param {string} options.email - account email
-     * @param {string} options.password - account password
+     * @param {string} options.quota - maximum quota for the account
      * @param {VaultClient~requestCallback} callback - callback
      * @returns {undefined}
      */
@@ -105,7 +105,17 @@ class VaultClient {
                'accountName is required');
         assert(typeof options.email === 'string' && options.email !== '',
                'options.email is required');
-
+        const data = {
+            Action: 'CreateAccount',
+            Version: '2010-05-08',
+            name: accountName,
+            emailAddress: options.email,
+        };
+        if (options.quota !== undefined && options.quota !== null) {
+            assert(typeof options.quota === 'number' && !isNaN(options.quota) &&
+                options.quota > 0, 'Quota must be a positive number');
+            data.quotaMax = options.quota;
+        }
         this.request('POST', '/', true, (err, result) => {
             if (err) {
                 return callback(err);
@@ -113,12 +123,7 @@ class VaultClient {
             return callback(null, {
                 account: result.account.data,
             });
-        }, {
-            Action: 'CreateAccount',
-            Version: '2010-05-08',
-            name: accountName,
-            emailAddress: options.email,
-        });
+        }, data);
     }
 
     /**
@@ -157,6 +162,44 @@ class VaultClient {
 
         this.request('POST', '/', true, callback, {
             Action: 'DeleteAccount',
+            Version: '2010-05-08',
+            AccountName: accountName,
+        });
+    }
+
+    /**
+     * Update Quota of an account
+     *
+     * @param {string} accountName - account name
+     * @param {integer} quota - maximum quota for the account
+     * @param {VaultClient~requestCallback} callback - callback
+     * @returns {undefined}
+     */
+    updateAccountQuota(accountName, quota, callback) {
+        assert(typeof accountName === 'string' && accountName !== '',
+            'accountName is required');
+        assert(typeof quota === 'number' && !isNaN(quota) &&
+            quota > 0, 'Quota must be a positive number');
+        this.request('POST', '/', true, callback, {
+            Action: 'UpdateAccountQuota',
+            Version: '2010-05-08',
+            AccountName: accountName,
+            quotaMax: quota,
+        });
+    }
+
+    /**
+     * Delete Quota of an account
+     *
+     * @param {string} accountName - account name
+     * @param {VaultClient~requestCallback} callback - callback
+     * @returns {undefined}
+     */
+    deleteAccountQuota(accountName, callback) {
+        assert(typeof accountName === 'string' && accountName !== '',
+            'accountName is required');
+        this.request('POST', '/', true, callback, {
+            Action: 'DeleteAccountQuota',
             Version: '2010-05-08',
             AccountName: accountName,
         });


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Add options in vaultclient to add, delete, update quotas on accounts.
- quota option when creating a new account
- update-account-quota: Update quotas on existing accounts
- delete-account-quota: Delete quotas from existing accounts

**Which issue does this PR fix?**
[S3C-1561](https://scality.atlassian.net/browse/S3C-1561)

**Special notes for your reviewers:**
ToDo after the feature is fully implemented in Vault:
- Add tests for the 3 new options. The same tests will be added in Vault, but need the options in vault client first.
- Update README for the new options