### PR TITLE
ft: S3C-2235 inject accountid, accesskey and secretkey

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -69,7 +69,7 @@ function action(cmd, fn, args) {
         let host = args.parent.host || process.env.VAULT_HOST || 'localhost';
         const client = new vaultclient.Client(host,
             Number.parseInt(args.parent.port ? args.parent.port :
-                            process.env.VAULT_PORT, 10),
+                process.env.VAULT_PORT, 10),
             useHttps,
             undefined,
             undefined,
@@ -104,20 +104,27 @@ program
     .option('--name <NAME>')
     .option('--email <EMAIL>')
     .option('--quota <Quota>', 'Maximum quota for the account', parseInt)
+    .option('--accountid <ExternalAccountID>')
     .action(action.bind(null, 'create-account', (client, args) => {
         client.createAccount(
             args.name, {
-                email: args.email,
-                quota: args.quota || null
-            },
+            email: args.email,
+            quota: args.quota || null,
+            externalAccountId: args.accountid || null
+        },
             handleVaultResponse);
     }));
 
 program
     .command('generate-account-access-key')
     .option('--name <NAME>')
+    .option('--accesskey <ExternalAccessKey>')
+    .option('--secretkey <ExternalSecretKey>')
     .action(action.bind(null, 'generate-account-access-key', (client, args) => {
-        client.generateAccountAccessKey(args.name, handleVaultResponse);
+        client.generateAccountAccessKey(args.name, handleVaultResponse, {
+            externalAccessKey: args.accesskey || null,
+            externalSecretKey: args.secretkey || null
+        });
     }));
 
 program

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -10,6 +10,9 @@ const https = require('https');
 const { parseString } = require('xml2js');
 const queryString = require('querystring');
 
+const regexAccountId = /^[0-9]{12}$/;
+const regexpAccessKey = /^[A-Z0-9]{20}$/;
+const regexpSecretKey = /^[A-Za-z0-9/+=]{40}$/;
 class VaultClient {
     /**
      * @constructor
@@ -115,9 +118,18 @@ class VaultClient {
         if (options.quota !== undefined && options.quota !== null) {
             const conv = Number.isNaN(Number.parseInt(options.quota, 10));
             assert(typeof options.quota === 'number'
-            && !conv
-            && options.quota > 0, 'Quota must be a positive number');
+                && !conv
+                && options.quota > 0, 'Quota must be a positive number');
             data.quotaMax = options.quota;
+        }
+        if (options.externalAccountId !== undefined
+            && options.externalAccountId !== null) {
+            const conv = Number.isNaN(Number
+                .parseInt(options.externalAccountId, 10));
+            assert(typeof options.externalAccountId === 'string'
+                && !conv && regexAccountId.test(options.externalAccountId),
+            'invalid account id supplied');
+            data.externalAccountId = options.externalAccountId;
         }
         this.request('POST', '/', true, (err, result) => {
             if (err) {
@@ -134,22 +146,42 @@ class VaultClient {
      *
      * @param {string} accountName - account name
      * @param {VaultClient~requestCallback} callback - callback
+     * @param {object} options - additional creation params
      * @returns {undefined}
      */
-    generateAccountAccessKey(accountName, callback) {
+    generateAccountAccessKey(accountName, callback, options) {
         assert(typeof accountName === 'string' && accountName !== '',
             'accountName is required');
+        const data = {
+            Action: 'GenerateAccountAccessKey',
+            Version: '2010-05-08',
+            AccountName: accountName,
+        };
+        if (options !== undefined) {
+            if (options.externalAccessKey !== undefined
+                && options.externalAccessKey !== null) {
+                assert(typeof options.externalAccessKey === 'string'
+                    && regexpAccessKey.test(options.externalAccessKey)
+                    && options.externalAccessKey !== '',
+                'invalid access key supplied');
+                data.externalAccessKey = options.externalAccessKey;
+            }
+            if (options.externalSecretKey !== undefined
+                && options.externalSecretKey !== null) {
+                assert(typeof options.externalSecretKey === 'string'
+                    && regexpSecretKey.test(options.externalSecretKey)
+                    && options.externalSecretKey !== '',
+                'invalid secret key supplied');
+                data.externalSecretKey = options.externalSecretKey;
+            }
+        }
 
         this.request('POST', '/', true, (err, result) => {
             if (err) {
                 return callback(err);
             }
             return callback(null, result.data);
-        }, {
-            Action: 'GenerateAccountAccessKey',
-            Version: '2010-05-08',
-            AccountName: accountName,
-        });
+        }, data);
     }
 
     /**
@@ -183,7 +215,7 @@ class VaultClient {
         assert(typeof accountName === 'string' && accountName !== '',
             'accountName is required');
         assert(typeof quota === 'number' && !conv
-        && quota > 0, 'Quota must be a positive number');
+            && quota > 0, 'Quota must be a positive number');
         this.request('POST', '/', true, callback, {
             Action: 'UpdateAccountQuota',
             Version: '2010-05-08',
@@ -227,7 +259,7 @@ class VaultClient {
         assert((accountIds && Array.isArray(accountIds)) || !accountIds,
             'accountIds should be an array');
         assert((emailAddresses && Array.isArray(emailAddresses))
-        || !emailAddresses, 'emailAddresses should be an array');
+            || !emailAddresses, 'emailAddresses should be an array');
         assert((canonicalIds && Array.isArray(canonicalIds)) || !canonicalIds,
             'canonicalIds should be an array');
         if (
@@ -235,7 +267,7 @@ class VaultClient {
             || (emailAddresses && (accountIds || canonicalIds))
             || (canonicalIds && (accountIds || emailAddresses))) {
             assert(false, 'accountIds, emailAddresses and canonicalIds '
-            + 'ids are exclusive');
+                + 'ids are exclusive');
         }
         const data = {
             Action: 'GetAccounts',


### PR DESCRIPTION
## Description
This includes includes the ability to inject ID, access key and secret key for an account.

### Motivation and context
[RFE-280](https://scality.atlassian.net/browse/RFE-280)

Why is this change required? What problem does it solve?
During Outscale POC, the customer requested to be able to set by themselves S3 Account ID, AccessKey and SecretKey. This fulfills the requirement for Outscale.

### Related issues
[S3C-2235](https://scality.atlassian.net/browse/S3C-2235)

###Usage
As we are using vaultclient, we can use it to add account ID during account creation:
`./bin/vaultclient create-account --name <account name> --email <email address> --accountid <accountID>`

similarly, access keys and secret keys can be manually supplied:
`./bin/vaultclient generate-account-access-key--name <account name> --accesskey <account access Key> --secretkey <account secret key>`

These options are independent of each other. They can be supplied individually or together.