### PR TITLE
ZENKO-2604 add ability to pass a context and request options

### DIFF
--- a/golang/vaultclient/createAccount.go
+++ b/golang/vaultclient/createAccount.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -78,8 +79,16 @@ func (s *CreateAccountInput) SetExternalAccountID(v string) *CreateAccountInput 
 }
 
 // CreateAccount API operation creates a new Vault account
-func (c *Vault) CreateAccount(input *CreateAccountInput) (*CreateAccountOutput, error) {
+// and adds the ability to pass a context and additional request options.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Vault) CreateAccount(ctx aws.Context, input *CreateAccountInput, opts ...request.Option) (*CreateAccountOutput, error) {
 	req, out := c.CreateAccountRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 

--- a/golang/vaultclient/createAccount_test.go
+++ b/golang/vaultclient/createAccount_test.go
@@ -2,6 +2,7 @@ package vaultclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -109,6 +110,7 @@ func TestCreateAccount(t *testing.T) {
 		for _, tc := range listCreateAccountTests {
 			description := tc.description
 			Convey(description, func() {
+				ctx := context.Background()
 				sess := session.Must(session.NewSession(&aws.Config{
 					Endpoint:   aws.String(server.URL),
 					Region:     aws.String("us-east-1"),
@@ -128,7 +130,7 @@ func TestCreateAccount(t *testing.T) {
 				if tc.externalAccountID != nil {
 					params.SetExternalAccountID(*tc.externalAccountID)
 				}
-				res, err := svc.CreateAccount(params)
+				res, err := svc.CreateAccount(ctx, params)
 				if tc.err != nil {
 					So(err.Error(), ShouldEqual, tc.err.Error())
 				} else {

--- a/golang/vaultclient/deleteAccount.go
+++ b/golang/vaultclient/deleteAccount.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -39,9 +40,17 @@ func (s *DeleteAccountInput) SetAccountName(v string) *DeleteAccountInput {
 	return s
 }
 
-// DeleteAccount API operation delete Vault account
-func (c *Vault) DeleteAccount(input *DeleteAccountInput) (*DeleteAccountOutput, error) {
+// DeleteAccount API operation deletes Vault account
+// and adds the ability to pass a context and additional request options.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Vault) DeleteAccount(ctx aws.Context, input *DeleteAccountInput, opts ...request.Option) (*DeleteAccountOutput, error) {
 	req, out := c.DeleteAccountRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 

--- a/golang/vaultclient/deleteAccount_test.go
+++ b/golang/vaultclient/deleteAccount_test.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -49,6 +50,7 @@ func TestDeleteAccount(t *testing.T) {
 		for _, tc := range listDeleteAccountTests {
 			description := tc.description
 			Convey(description, func() {
+				ctx := context.Background()
 				sess := session.Must(session.NewSession(&aws.Config{
 					Endpoint:   aws.String(server.URL),
 					Region:     aws.String("us-east-1"),
@@ -59,7 +61,7 @@ func TestDeleteAccount(t *testing.T) {
 				if tc.accountName != nil {
 					params.SetAccountName(*tc.accountName)
 				}
-				_, err := svc.DeleteAccount(params)
+				_, err := svc.DeleteAccount(ctx, params)
 				if tc.err != nil {
 					So(err.Error(), ShouldEqual, tc.err.Error())
 				} else {

--- a/golang/vaultclient/generateAccountAccessKey.go
+++ b/golang/vaultclient/generateAccountAccessKey.go
@@ -3,6 +3,7 @@ package vaultclient
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -64,8 +65,16 @@ func (s *GenerateAccountAccessKeyInput) SetExternalSecretKey(v string) *Generate
 }
 
 // GenerateAccountAccessKey API operation generates a new access key for the account
-func (c *Vault) GenerateAccountAccessKey(input *GenerateAccountAccessKeyInput) (*GenerateAccountAccessKeyOutput, error) {
+// and adds the ability to pass a context and additional request options.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Vault) GenerateAccountAccessKey(ctx aws.Context, input *GenerateAccountAccessKeyInput, opts ...request.Option) (*GenerateAccountAccessKeyOutput, error) {
 	req, out := c.GenerateAccountAccessKeyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 

--- a/golang/vaultclient/generateAccountAccesskey_test.go
+++ b/golang/vaultclient/generateAccountAccesskey_test.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -71,6 +72,7 @@ func TestGenerateAccountAccessKey(t *testing.T) {
 		for _, tc := range generateKeyTests {
 			description := tc.description
 			Convey(description, func() {
+				ctx := context.Background()
 				sess := session.Must(session.NewSession(&aws.Config{
 					Endpoint:   aws.String(server.URL),
 					Region:     aws.String("us-east-1"),
@@ -87,7 +89,7 @@ func TestGenerateAccountAccessKey(t *testing.T) {
 				if tc.externalAccessKey != nil {
 					params.SetExternalAccessKey(*tc.externalAccessKey)
 				}
-				res, err := svc.GenerateAccountAccessKey(params)
+				res, err := svc.GenerateAccountAccessKey(ctx, params)
 				if tc.err != nil {
 					So(err.Error(), ShouldEqual, tc.err.Error())
 				} else {

--- a/golang/vaultclient/listAccounts.go
+++ b/golang/vaultclient/listAccounts.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -57,8 +58,16 @@ func (s *ListAccountsInput) SetMaxItems(v int64) *ListAccountsInput {
 }
 
 // ListAccounts API operation lists Vault accounts
-func (c *Vault) ListAccounts(input *ListAccountsInput) (*ListAccountsOutput, error) {
+// and adds the ability to pass a context and additional request options.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Vault) ListAccounts(ctx aws.Context, input *ListAccountsInput, opts ...request.Option) (*ListAccountsOutput, error) {
 	req, out := c.ListAccountsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 

--- a/golang/vaultclient/listAccounts_test.go
+++ b/golang/vaultclient/listAccounts_test.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -72,6 +73,7 @@ func TestListAccounts(t *testing.T) {
 		for _, tc := range listListAccountsTests {
 			description := tc.description
 			Convey(description, func() {
+				ctx := context.Background()
 				sess := session.Must(session.NewSession(&aws.Config{
 					Endpoint:   aws.String(server.URL),
 					Region:     aws.String("us-east-1"),
@@ -85,7 +87,7 @@ func TestListAccounts(t *testing.T) {
 				if tc.maxItems != nil {
 					params.SetMaxItems(*tc.maxItems)
 				}
-				res, err := svc.ListAccounts(params)
+				res, err := svc.ListAccounts(ctx, params)
 				if tc.err != nil {
 					So(err.Error(), ShouldEqual, tc.err.Error())
 				} else {


### PR DESCRIPTION
This will add the ability to use (non-exhaustive):

- context for request cancellation
- options to the retrieve headers from the HTTP response and assign them to the passed in headers variable
- options to set the request to use a specific log level when the request is made