### PR TITLE
bugfix: S3C-2576-allow-0-value-as-quota

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -128,7 +128,7 @@ class VaultClient {
             const conv = Number.isNaN(Number.parseInt(options.quota, 10));
             assert(typeof options.quota === 'number'
                 && !conv
-                && options.quota > 0, 'Quota must be a positive number');
+                && options.quota >= 0, 'Quota must be a non-negative number');
             data.quotaMax = options.quota;
         }
         if (options.externalAccountId !== undefined
@@ -224,7 +224,7 @@ class VaultClient {
         assert(typeof accountName === 'string' && accountName !== '',
             'accountName is required');
         assert(typeof quota === 'number' && !conv
-            && quota > 0, 'Quota must be a positive number');
+            && quota >= 0, 'Quota must be a non-negative number');
         this.request('POST', '/', true, callback, {
             Action: 'UpdateAccountQuota',
             Version: '2010-05-08',


### PR DESCRIPTION
Allow quota value to be set as zero.

Default behaviour: Setting the quota value to zero is the same as not setting the quota value at all.
The value is assumed unset and no quota is imposed on the account.

Note to reviewers: Please ignore the circle CI test. Its legacy platform. I am working with RELENG to get it removed.
pre-merge is the usual one for our builds