### PR TITLE
INTEGRATION [PR#258 > development/7.9] bugfix: S3C-3388 use constant httpClientFreeSocketTimeout

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 'use strict'; // eslint-disable-line
 
-const { auth, errors } = require('arsenal');
+const { auth, errors, constants } = require('arsenal');
 const assert = require('assert');
 const werelogs = require('werelogs');
 const http = require('http');
@@ -11,11 +11,6 @@ const { parseString } = require('xml2js');
 const queryString = require('querystring');
 const HttpAgent = require('agentkeepalive');
 const { HttpsAgent } = require('agentkeepalive');
-
-// bucketd server is configured to wait 60 seconds of inactivity on a
-// HTTP socket before closing it, so we might reuse it safely for a
-// little bit less time to avoid ECONNRESET issues
-const FREE_SOCKET_TIMEOUT = 55000;
 
 class VaultClient {
     /**
@@ -59,12 +54,12 @@ class VaultClient {
                 keepAlive: true,
                 requestCert: true,
                 rejectUnauthorized: !(ignoreCa === true),
-                freeSocketTimeout: FREE_SOCKET_TIMEOUT,
+                freeSocketTimeout: constants.httpClientFreeSocketTimeout,
             });
         } else {
             this._agent = new HttpAgent({
                 keepAlive: true,
-                freeSocketTimeout: FREE_SOCKET_TIMEOUT,
+                freeSocketTimeout: constants.httpClientFreeSocketTimeout,
             });
         }
         this.accessKey = accessKey;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/scality/vaultclient#readme",
   "dependencies": {
     "agentkeepalive": "^4.1.3",
-    "arsenal": "scality/Arsenal#efdffd6",
+    "arsenal": "scality/Arsenal#918a1d7",
     "commander": "2.20.0",
     "werelogs": "scality/werelogs#4e0d97c",
     "xml2js": "0.4.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,15 +249,15 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-arsenal@scality/Arsenal#efdffd6:
+arsenal@scality/Arsenal#918a1d7:
   version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/efdffd6b99bc52445e93041d6c5cc93a0d541ffb"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/918a1d7c899a7ecddcd1d6e7bbdd49b5becc5bd0"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "6.12.2"
     async "~2.1.5"
-    debug "~2.3.3"
+    debug "~2.6.9"
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.9.1"
@@ -524,7 +524,7 @@ debug@3.2.6, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^2.6.8, debug@^2.6.9:
+debug@^2.6.8, debug@^2.6.9, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -537,13 +537,6 @@ debug@^4.0.1, debug@^4.1.0, debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  integrity sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=
-  dependencies:
-    ms "0.7.2"
 
 debug@~3.1.0:
   version "3.1.0"
@@ -1687,11 +1680,6 @@ mocha@6.1.4:
     yargs "13.2.2"
     yargs-parser "13.0.0"
     yargs-unparser "1.5.0"
-
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #258.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3388-useArsenalConstantFreeSocketTimeout`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3388-useArsenalConstantFreeSocketTimeout
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3388-useArsenalConstantFreeSocketTimeout
```

Please always comment pull request #258 instead of this one.