### PR TITLE
feature: S3C-4090-create-account-with-customAttributes

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -120,21 +120,25 @@ class VaultClient {
             name: accountName,
             emailAddress: options.email,
         };
-        if (options.quota !== undefined && options.quota !== null) {
-            const conv = Number.isNaN(Number.parseInt(options.quota, 10));
-            assert(typeof options.quota === 'number'
+        const { quota, externalAccountId, customAttributes } = options;
+        if (quota) {
+            const conv = Number.isNaN(Number.parseInt(quota, 10));
+            assert(typeof quota === 'number'
                 && !conv
-                && options.quota >= 0, 'Quota must be a non-negative number');
-            data.quotaMax = options.quota;
+                && quota >= 0, 'Quota must be a non-negative number');
+            data.quotaMax = quota;
         }
-        if (options.externalAccountId !== undefined
-            && options.externalAccountId !== null) {
-            const conv = Number.isNaN(Number
-                .parseInt(options.externalAccountId, 10));
-            assert(typeof options.externalAccountId === 'string'
-                && !conv && regexAccountId.test(options.externalAccountId),
+        if (externalAccountId) {
+            const conv = Number.isNaN(Number.parseInt(externalAccountId, 10));
+            assert(typeof externalAccountId === 'string'
+                && !conv
+                && regexAccountId.test(externalAccountId),
             'invalid account id supplied');
-            data.externalAccountId = options.externalAccountId;
+            data.externalAccountId = externalAccountId;
+        }
+        if (customAttributes) {
+            assert(typeof customAttributes === 'object');
+            data.customAttributes = JSON.stringify(customAttributes);
         }
         this.request('POST', '/', true, (err, result) => {
             if (err) {


### PR DESCRIPTION
`CreateAccount` now supports `customAttribute` which can be used to store relationships to an account with 3rd party ISVs.

Example: In the case of vCloud Director Object Storage Extension, we need to store vCloud Director tenant IDs.