### PR TITLE
INTEGRATION [PR#310 > development/8.2] ft(S3C-4383): Add getAccountIds

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -674,6 +674,38 @@ class VaultClient {
     }
 
     /**
+     * A getter for accountIds given a list of canonicalIDs
+     * @param {String[]} canonicalIds - list of canonicalIDs
+     * @param {Object} options - additional arguments
+     * @param {string} options.reqUid - the request UID
+     * @param {werelogs.RequestLogger} [options.logger] - Logger instance
+     * @param {Function} callback - the callback handling the response object
+     * and the error, if there is one
+     * @returns {undefined}
+     */
+    getAccountIds(canonicalIds, options, callback) {
+        this.getAccounts(null, null, canonicalIds, options,
+            (err, res, code) => {
+                if (err) {
+                    return callback(err);
+                }
+                const body = res.reduce((accounts, account) => {
+                    // eslint-disable-next-line no-param-reassign
+                    accounts[account.canId] = account.id;
+                    return accounts;
+                }, {});
+
+                return callback(null, {
+                    message: {
+                        body,
+                        code,
+                        message: 'Attributes retrieved',
+                    },
+                });
+            });
+    }
+
+    /**
      * Get policy evaluation (without authentication first)
      * @param {Object} requestContextParams - parameters needed to construct
      * requestContext in Vault

--- a/tests/unit/getAccountIds.js
+++ b/tests/unit/getAccountIds.js
@@ -1,0 +1,84 @@
+/* eslint-disable operator-linebreak */
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const { errors } = require('arsenal');
+const http = require('http');
+const querystring = require('querystring');
+const IAMClient = require('../../lib/IAMClient.js');
+
+const canId1 =
+    '0123456789012345678901234567890123456789012345678901234567890123';
+const canId2 =
+    '1234567890123456789012345678901234567890123456789012345678901230';
+const canId3 =
+    '2345678901234567890123456789012345678901234567890123456789012301';
+
+const accountId1 = 'accountId1';
+const accountId2 = 'accountId2';
+const accountId3 = 'accountId3';
+
+const serverDB = {};
+serverDB[accountId1] = canId1;
+serverDB[accountId2] = canId2;
+serverDB[accountId3] = canId3;
+
+serverDB[canId1] = accountId1;
+serverDB[canId2] = accountId2;
+serverDB[canId3] = accountId3;
+
+function handler(req, res) {
+    const index = req.url.indexOf('?');
+    const data = querystring.parse(req.url.substring(index + 1));
+    let inputArray = data.canonicalIds;
+    if (!Array.isArray(inputArray)) {
+        inputArray = [inputArray];
+    }
+    if (req.headers['x-scal-request-uids'] === 'failme') {
+        res.writeHead(errors.InvalidParameterValue.code);
+        return res.end(JSON.stringify(errors.InvalidParameterValue));
+    }
+    const output = inputArray.map(canId => ({
+        id: serverDB[canId],
+        canId,
+    }));
+    res.writeHead(200);
+    return res.end(JSON.stringify(output), null, 4);
+}
+
+describe('getAccountIds with mockup server', () => {
+    let server;
+    let client;
+
+    beforeEach('start server', done => {
+        server = http.createServer(handler).listen(8500);
+        client = new IAMClient('127.0.0.1', 8500);
+        done();
+    });
+
+    afterEach('stop server', () => { server.close(); });
+
+    it('should correctly retrieve account Ids', done => {
+        const canIds = [canId1, canId2, canId3];
+        const expectedRes = {
+            [canId1]: accountId1,
+            [canId2]: accountId2,
+            [canId3]: accountId3,
+        };
+        client.getAccountIds(canIds, {}, (err, res) => {
+            if (err) {
+                return done(err);
+            }
+            assert.deepStrictEqual(res.message.body, expectedRes);
+            return done();
+        });
+    });
+
+    it('should return error when server returns an error', done => {
+        const canIds = [canId1, canId2];
+        client.getAccountIds(canIds, { reqUid: 'failme' }, err => {
+            assert(err);
+            return done();
+        });
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #310.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-4383_add_getAccountIds_to_vaultclient`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-4383_add_getAccountIds_to_vaultclient
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-4383_add_getAccountIds_to_vaultclient
```

Please always comment pull request #310 instead of this one.