### PR TITLE
Add command to create builtin managemet account

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -12,6 +12,10 @@ const vaultclient = require('../index');
 
 const version = require('../package.json').version;
 
+const internalServiceAccountId = '000000000000';
+const internalServiceAccountName = 'scality-internal-services';
+const internalServiceAccountEmail = 'scality@internal';
+
 program.version(version)
     .option('--host [HOST]', 'host where Vault is running (default to ' +
         'VAULT_HOST environment variable)')
@@ -207,6 +211,54 @@ program
     .option('--name <NAME>')
     .action(action.bind(null, 'delete-account', (client, args) => {
         client.deleteAccount(args.name, handleVaultResponse);
+    }));
+
+program
+    .command('ensure-internal-services-account')
+    .option('--accesskey <AccessKey>')
+    .option('--secretkey <SecretKey>')
+    .action(action.bind(null, 'ensure-internal-management-account', (client, args) => {
+        const ensureAccessKey = err => {
+            if (err) {
+                return handleVaultResponse(err);
+            }
+            const params = {
+                externalAccessKey: args.accesskey,
+                externalSecretKey: args.secretkey,
+            };
+            return client.generateAccountAccessKey(internalServiceAccountName,
+                (err, data) => {
+                    if (err && err.EntityAlreadyExists) {
+                        return handleVaultResponse(null, data);
+                    }
+                    return handleVaultResponse(err, data);
+                }, params);
+        };
+
+        client.getAccount({ accountId: internalServiceAccountId }, (err, data) => {
+            if (!err) {
+                if (data.name !== internalServiceAccountName || data.emailAddress !== internalServiceAccountEmail) {
+                    return handleVaultResponse({
+                        errorMessage: "An account already exists with id "+internalServiceAccountId,
+                        existingAccount: data,
+                    });
+                }
+
+                return ensureAccessKey();
+            }
+
+            if (err.NoSuchEntity) {
+                return client.createAccount(
+                    internalServiceAccountName, {
+                        email: internalServiceAccountEmail,
+                        externalAccountId: internalServiceAccountId,
+                        // TODO add flag here to not seed the account S3C-4656
+                    },
+                    ensureAccessKey);
+            }
+
+            return handleVaultResponse(err);
+        });
     }));
 
 program

--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -52,6 +52,23 @@ function readConfigFile(configFilePath) {
     }
 };
 
+/**
+ * Gets admin credentials via environment variables or via config file
+ *
+ * @param configFilePath - path to the admin config
+ * @returns {object} - admin credentials
+ */
+function getAdminConfig(configFilePath) {
+    if (process.env.ADMIN_ACCESS_KEY_ID && process.env.ADMIN_SECRET_ACCESS_KEY) {
+        return {
+            accessKey: process.env.ADMIN_ACCESS_KEY_ID,
+            secretKeyValue: process.env.ADMIN_SECRET_ACCESS_KEY,
+        }
+    }
+    return readConfigFile(configFilePath);
+}
+
+
 function action(cmd, fn, args) {
     if (typeof args !== 'object') {
         program.commands.find(c => c._name === cmd).outputHelp();
@@ -63,7 +80,7 @@ function action(cmd, fn, args) {
         const ca = args.parent.cafile ?
             fs.readFileSync(args.parent.cafile, 'ascii') : undefined;
         const untrusted = args.parent.noCaVerification ? true : false;
-        const config = readConfigFile(args.parent.config);
+        const config = getAdminConfig(args.parent.config);
         const accessKey = config.accessKey;
         const secretKey = config.secretKeyValue;
         let host = args.parent.host || process.env.VAULT_HOST || 'localhost';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "7.10.0",
+  "version": "7.10.1",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
   "repository": "scality/vaultclient",


### PR DESCRIPTION
Adds a `ensure-internal-services-account` command that creates an account with id 0, and a fixed name and email.
- An access key/secret key pair can be provided
- When a do-not-seed-roles-and-policies flag is implemented in Vault CreateAccount (soon) this will be the place to use it

This command is idempotent and meant to be used automatically when deploying.

Note: idempotency relies on scality/vault#feature/S3C-4505-key-gen-conflict