### PR TITLE
INTEGRATION [PR#319 > development/8.2] Add command to create builtin managemet account

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -12,6 +12,10 @@ const vaultclient = require('../index');
 
 const version = require('../package.json').version;
 
+const internalServiceAccountId = '000000000000';
+const internalServiceAccountName = 'scality-internal-services';
+const internalServiceAccountEmail = 'scality@internal';
+
 program.version(version)
     .option('--host [HOST]', 'host where Vault is running (default to ' +
         'VAULT_HOST environment variable)')
@@ -198,6 +202,54 @@ program
     .option('--name <NAME>')
     .action(action.bind(null, 'delete-account', (client, args) => {
         client.deleteAccount(args.name, handleVaultResponse);
+    }));
+
+program
+    .command('ensure-internal-services-account')
+    .option('--accesskey <AccessKey>')
+    .option('--secretkey <SecretKey>')
+    .action(action.bind(null, 'ensure-internal-management-account', (client, args) => {
+        const ensureAccessKey = err => {
+            if (err) {
+                return handleVaultResponse(err);
+            }
+            const params = {
+                externalAccessKey: args.accesskey,
+                externalSecretKey: args.secretkey,
+            };
+            return client.generateAccountAccessKey(internalServiceAccountName,
+                (err, data) => {
+                    if (err && err.EntityAlreadyExists) {
+                        return handleVaultResponse(null, data);
+                    }
+                    return handleVaultResponse(err, data);
+                }, params);
+        };
+
+        client.getAccount({ accountId: internalServiceAccountId }, (err, data) => {
+            if (!err) {
+                if (data.name !== internalServiceAccountName || data.emailAddress !== internalServiceAccountEmail) {
+                    return handleVaultResponse({
+                        errorMessage: "An account already exists with id "+internalServiceAccountId,
+                        existingAccount: data,
+                    });
+                }
+
+                return ensureAccessKey();
+            }
+
+            if (err.NoSuchEntity) {
+                return client.createAccount(
+                    internalServiceAccountName, {
+                        email: internalServiceAccountEmail,
+                        externalAccountId: internalServiceAccountId,
+                        // TODO add flag here to not seed the account S3C-4656
+                    },
+                    ensureAccessKey);
+            }
+
+            return handleVaultResponse(err);
+        });
     }));
 
 program

--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -36,7 +36,15 @@ function checkConfig(configObject) {
     }
 }
 
-function readConfigFile(configFilePath) {
+function readConfig(configFilePath) {
+    const accessKey = process.env.VAULT_ACCESS_KEY;
+    const secretKeyValue = process.env.VAULT_SECRET_KEY;
+    if (accessKey && secretKeyValue) {
+        return {
+            accessKey,
+            secretKeyValue,
+        };
+    }
     let actualPath = path.join(homedir(), '.vaultclient.conf');
     if (configFilePath) {
         actualPath = configFilePath;
@@ -63,7 +71,7 @@ function action(cmd, fn, args) {
         const ca = args.parent.cafile ?
             fs.readFileSync(args.parent.cafile, 'ascii') : undefined;
         const untrusted = args.parent.noCaVerification ? true : false;
-        const config = readConfigFile(args.parent.config);
+        const config = readConfig(args.parent.config);
         const accessKey = config.accessKey;
         const secretKey = config.secretKeyValue;
         let host = args.parent.host || process.env.VAULT_HOST || 'localhost';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "7.10.0",
+  "version": "7.10.1",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
   "repository": "scality/vaultclient",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #319.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-4505-create-builtin-mgmt-account`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-4505-create-builtin-mgmt-account
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-4505-create-builtin-mgmt-account
```

Please always comment pull request #319 instead of this one.