### PR TITLE
INTEGRATION [PR#327 > development/8.2] VLTCLT-1 update werelogs to a properly tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "agentkeepalive": "^4.1.3",
     "arsenal": "scality/Arsenal#918a1d7",
     "commander": "2.20.0",
-    "werelogs": "scality/werelogs#4e0d97c",
+    "werelogs": "scality/werelogs#8.1.0",
     "xml2js": "0.4.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,9 +2561,9 @@ werelogs@scality/werelogs#0ff7ec82:
   dependencies:
     safe-json-stringify "1.0.3"
 
-werelogs@scality/werelogs#4e0d97c:
-  version "7.4.1"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/4e0d97cf69ea7ed60bea90756278513e7e7ea9b1"
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #327.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/VLTCLT-1-upgrade-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/VLTCLT-1-upgrade-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/VLTCLT-1-upgrade-werelogs
```

Please always comment pull request #327 instead of this one.