### PR TITLE
Authenticate getaccounts

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -67,7 +67,8 @@ function getAdminConfig(configFilePath) {
         return {
             accessKey: process.env.ADMIN_ACCESS_KEY_ID,
             secretKeyValue: process.env.ADMIN_SECRET_ACCESS_KEY,
-        }
+            sessionToken: process.env.ADMIN_SESSION_TOKEN, // token is optional
+        };
     }
     return readConfigFile(configFilePath);
 }
@@ -88,6 +89,7 @@ function action(cmd, fn, args) {
         const accessKey = config.accessKey;
         const secretKey = config.secretKeyValue;
         let host = args.parent.host || process.env.VAULT_HOST || 'localhost';
+        const token = config.sessionToken;
         const client = new vaultclient.Client(host,
             Number.parseInt(args.parent.port ? args.parent.port :
                 process.env.VAULT_PORT, 10),
@@ -97,7 +99,10 @@ function action(cmd, fn, args) {
             ca,
             untrusted,
             accessKey,
-            secretKey);
+            secretKey,
+            null,
+            null,
+            token);
         fn(client, args);
     } catch (err) {
         //process.stderr.write(err.message + '\n');
@@ -188,6 +193,21 @@ program
             canonicalId: args.canonicalId || undefined,
             emailAddress: args.email || undefined,
         }, handleVaultResponse);
+    }));
+
+program
+    .command('get-accounts')
+    .option('--account-ids <ACCOUNT ID,ACCOUNT ID,...>')
+    .option('--canonical-ids <CANONICAL ID,CANONICAL ID,...>')
+    .option('--emails <EMAIL,EMAIL,...>')
+    .action(action.bind(null, 'get-accounts', (client, args) => {
+        client.enableIAMOnAdminRoutes().getAccounts(
+            args.accountIds ? args.accountIds.split(',') : null,
+            args.canonicalIds ? args.canonicalIds.split(',') : null,
+            args.emails ? args.emails.split(',') : null,
+            {},
+            handleVaultResponse,
+        );
     }));
 
 program

--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -202,9 +202,9 @@ program
     .option('--emails <EMAIL,EMAIL,...>')
     .action(action.bind(null, 'get-accounts', (client, args) => {
         client.enableIAMOnAdminRoutes().getAccounts(
-            args.accountIds ? args.accountIds.split(',') : null,
-            args.canonicalIds ? args.canonicalIds.split(',') : null,
-            args.emails ? args.emails.split(',') : null,
+            args.accountIds?.split(',') || null,
+            args.canonicalIds?.canonicalIds.split(',') || null,
+            args.emails?.emails.split(',') || null,
             {},
             handleVaultResponse,
         );

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -31,9 +31,10 @@ class VaultClient {
      * @param {Werelogs.API} [logApi] - object providing a constructor function
      *                                  for the Logger object
      * @param {string} [path] - prefix requests with this path
+     * @param {string} [sessionToken] - session token for v4 signature
      */
     constructor(host, port, useHttps, key, cert, ca, ignoreCa,
-        accessKey, secretKeyValue, logApi, path) {
+        accessKey, secretKeyValue, logApi, path, sessionToken) {
         assert(typeof host === 'string' && host !== '', 'host is required');
         assert(port === undefined || typeof port === 'number',
             'port must be a number');
@@ -43,7 +44,7 @@ class VaultClient {
             'cert must be a string');
         assert(ca === undefined || typeof ca === 'string',
             'ca must be a string');
-        assert(path === undefined
+        assert(path === undefined || path === null
             || (typeof path === 'string' && path.startsWith('/')),
         'path must be a string and start with a "/"');
         this.serverHost = host;
@@ -68,9 +69,16 @@ class VaultClient {
         }
         this.accessKey = accessKey;
         this.secretKeyValue = secretKeyValue;
+        this.sessionToken = sessionToken;
         this.logApi = logApi || werelogs;
         this.log = new this.logApi.Logger('VaultClient');
         this._path = path;
+        this.useAuthenticatedAdminRoutes = false;
+    }
+
+    enableIAMOnAdminRoutes() {
+        this.useAuthenticatedAdminRoutes = true;
+        return this;
     }
 
     /**
@@ -359,7 +367,10 @@ class VaultClient {
         if (emailAddresses) {
             data.emailAddresses = emailAddresses;
         }
-        this.request('GET', '/', false, callback, data, options.reqUid, null);
+
+        const verb = this.useAuthenticatedAdminRoutes ? 'POST' : 'GET';
+
+        this.request(verb, '/', this.useAuthenticatedAdminRoutes, callback, data, options.reqUid, null);
     }
 
     /**
@@ -864,7 +875,8 @@ class VaultClient {
             ? https.request(options) : http.request(options);
         if (iamAuthenticate) {
             auth.client.generateV4Headers(req, data,
-                this.accessKey, this.secretKeyValue, 'iam', path);
+                this.accessKey, this.secretKeyValue, 'iam', path,
+                this.sessionToken);
         }
         if (method === 'POST') {
             if (contentType === 'application/json') {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.2",
+  "version": "7.10.4",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
   "repository": "scality/vaultclient",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/scality/vaultclient#readme",
   "dependencies": {
     "agentkeepalive": "^4.1.3",
-    "arsenal": "scality/Arsenal#7.10.9",
+    "arsenal": "scality/Arsenal#7.10.11",
     "commander": "2.20.0",
     "werelogs": "scality/werelogs#8.1.0",
     "xml2js": "0.4.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,9 +254,9 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-arsenal@scality/Arsenal#7.10.9:
-  version "7.10.9"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/2f40ff388327b17728926bf99fe82b0e6a14a01d"
+arsenal@scality/Arsenal#7.10.11:
+  version "7.10.11"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/4303cd8f5b3dc9f1f47d382e5355c7e357e4c5f2"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
This uses a new POST route for GetAccounts in vault, that authenticates and authorizes the call and works with session tokens.

The new auth is opt-in, existing code will not use it unless it is changed to call `.enableIAMOnAdminRoutes()`