### PR TITLE
Feature/vltclt 19 add super admin get user by access key

### DIFF
--- a/bin/vaultclient
+++ b/bin/vaultclient
@@ -282,6 +282,13 @@ program
     }));
 
 program
+    .command('get-user-by-access-key')
+    .option('--access-key <Access Key>')
+    .action(action.bind(null, 'get-user-by-access-key', (client, args) => {
+        client.getUserByAccessKey(args.accessKey || undefined, handleVaultResponse);
+    }));
+
+program
     .command('*')
     .action(() => {
         program.outputHelp();

--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -751,6 +751,26 @@ class VaultClient {
     }
 
     /**
+     * A getter of User given one of his access keys
+     * @param {string} accessKey - the access key
+     * @param {Function} callback - the callback handling the response object
+     * and the error, if there is one
+     * @returns {undefined}
+     */
+    getUserByAccessKey(accessKey, callback) {
+        assert(accessKey !== undefined, 'accessKey need to be specified');
+        assert(typeof accessKey === 'string', 'accessKey should be a string');
+        assert(accessKey !== '', 'accessKey should not be empty string');
+
+        const data = {
+            Action: 'GetUserByAccessKey',
+            Version: '2010-05-08',
+            accessKey,
+        };
+        this.request('GET', '/', true, callback, data);
+    }
+
+    /**
      * Get policy evaluation (without authentication first)
      * @param {Object} requestContextParams - parameters needed to construct
      * requestContext in Vault

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.8",
+  "version": "7.10.9",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
   "repository": "scality/vaultclient",

--- a/tests/unit/getUserByAccessKey.js
+++ b/tests/unit/getUserByAccessKey.js
@@ -1,0 +1,81 @@
+/* eslint-disable operator-linebreak */
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const http = require('http');
+const { errors } = require('arsenal');
+const querystring = require('querystring');
+const IAMClient = require('../../lib/IAMClient');
+
+
+const testUserId = 'testUserId';
+const testAccessKey = 'testAccessKey';
+const testSecretKey = 'testSecretKey';
+const notExistingAccessKey = 'notExistingAccessKey';
+
+const serverDB = {
+    [testAccessKey]: {
+        id: testAccessKey,
+        value: testSecretKey,
+        createDate: '2022-08-11T17:57:00Z',
+        status: 'Active',
+        userId: testUserId,
+    },
+    [testUserId]: {
+        arn: 'arn:aws:iam::405435207934:user/bart',
+        id: testUserId,
+        emailAddress: '',
+        name: 'bart',
+        createDate: '2022-08-11T17:57:00Z',
+        parentId: '405435207934',
+    },
+};
+
+function handler(req, res) {
+    const index = req.url.indexOf('?');
+    const data = querystring.parse(req.url.substring(index + 1));
+
+    let output = null;
+    try {
+        res.writeHead(200);
+        const accessKeyObject = serverDB[data.accessKey];
+        const userObject = serverDB[accessKeyObject.userId];
+        output = JSON.stringify(userObject);
+        return res.end(output, null, 4);
+    } catch (e) {
+        res.writeHead(errors.EntityDoesNotExist.code);
+        return res.end(JSON.stringify(errors.EntityDoesNotExist));
+    }
+}
+
+describe('GetUserByAccessKey with mockup server', () => {
+    let server;
+    let client;
+
+    beforeEach('start server', done => {
+        server = http.createServer(handler).listen(8500);
+        client = new IAMClient('127.0.0.1', 8500);
+        done();
+    });
+
+    afterEach('stop server', () => { server.close(); });
+
+    it('should correctly retrieve user info by accessKey', done => {
+        const expectedUser = serverDB[serverDB[testAccessKey].userId];
+        client.getUserByAccessKey(testAccessKey, (err, res) => {
+            if (err) {
+                return done(err);
+            }
+            assert.deepStrictEqual(res, expectedUser);
+            return done();
+        });
+    });
+
+    it('should return error if accessKey doesn\'t exist', done => {
+        client.getUserByAccessKey(notExistingAccessKey, (err, res) => {
+            assert(err);
+            assert(!res);
+            return done();
+        });
+    });
+});


### PR DESCRIPTION
the full context is described [in this TAD](https://scality.atlassian.net/wiki/spaces/OS/pages/1958838282/Vault+superAdmin+API+getUserByAccessKey+for+supporting+non+standard+VMware+VCD+OSE+updateCredentialStatus)

simply to say, VMware doesn't follow their API standard for the `updateCredentialStatus` API, so we need to find a workaround to be able to get the user and account information by a given accessKey(accessKey is unique cross the db), so we introduced this superAdmin API in VAULT and vaultclient.