### PR TITLE
VLTCLT-28 attribute API request parameter change

### DIFF
--- a/lib/IAMClient.js
+++ b/lib/IAMClient.js
@@ -309,19 +309,19 @@ class VaultClient {
     /**
      * Update account custom attributes
      *
-     * @param {string} accountName - account name
+     * @param {string} name - account name
      * @param {object} customAttributes - custom attributes
      * @param {VaultClient~requestCallback} callback - callback
      * @returns {undefined}
      */
-    updateAccountAttributes(accountName, customAttributes, callback) {
-        assert(typeof accountName === 'string' && accountName !== '',
-            'accountName is required');
+    updateAccountAttributes(name, customAttributes, callback) {
+        assert(typeof name === 'string' && name !== '',
+            'name parameter is required for account name');
         assert(typeof customAttributes === 'object');
         this.request('POST', '/', true, callback, {
             Action: 'UpdateAccountAttributes',
             Version: '2010-05-08',
-            accountName,
+            name,
             customAttributes: JSON.stringify(customAttributes),
         });
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.11",
+  "version": "7.10.12",
   "description": "Client library and binary for Vault, the user directory and key management service",
   "main": "index.js",
   "repository": "scality/vaultclient",


### PR DESCRIPTION
Change in Request Parameter for Vault Admin API "UpdateAccountAttribute"

The "accountName" request parameter for specifying the name of the
account/root user has been updated to "name" in the Vault Admin API
"UpdateAccountAttribute". This change has been made to enhance the
clarity and consistency of the API parameters for OSIS adapter.

Tested in: https://github.com/scality/Vault/pull/2117