### PR TITLE
VLTCLT-59 bump CI runner OS

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Ubuntu 20.04 is soon to be removed from GitHub Actions