### PR TITLE
VLTCLT-64 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,8 +11,8 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'yarn'


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

Closes VLTCLT-64

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Timeline:
- June 2, 2026: Runners default to Node 24 (deprecation warnings)
- Fall 2026: Node 20 completely removed

## Changes
Updated action versions across workflow files to Node 24-compatible versions:
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `docker/build-push-action@v5` → `@v7`
- `docker/login-action@v3` → `@v4`
- `docker/setup-buildx-action@v3` → `@v4`
- `codecov/codecov-action@v4/@v5` → `@v6`
- `softprops/action-gh-release@v2` → `@v3`